### PR TITLE
switch to eslint-config-airbnb-base

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 buildium
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,34 +8,22 @@ Make sure you have the peer dependencies installed:
 
 npm i eslint-plugin-buildium
 
-npm i eslint-config-airbnb
+npm i eslint-config-airbnb-base
+
+```shell
+npm install eslint-config-buildium eslint-plugin-buildium eslint-config-airbnb-base eslint-plugin-import eslint --save-dev
+```
 
 And add buildium to your .eslintrc in the extend field:
 
+```json
 {
-    extend: "buildium"
+    "extend": "buildium"
 }
+```
 
-## License
+Or call `eslint` with buildium as the shared config
 
-The MIT License (MIT)
-
-Copyright (c) 2015 buildium
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+```shell
+eslint --config buildium src/**
+```

--- a/eslintrc.js
+++ b/eslintrc.js
@@ -1,23 +1,34 @@
 module.exports = {
-    "extends": "airbnb/legacy",
+    "extends": "airbnb-base",
     "plugins": [
         "buildium"
     ],
     "rules": {
-        "indent": [2, 4, {"SwitchCase": 1}], //our indentation
-        "comma-dangle": 0, //don't require dangling comma
-        "strict": [2, "global"], //use the global strict keyword
-        "no-else-return": 0, //allow return in else blocks
-        "func-names": 0, //we can use a custom rule for func names
-        "spaced-comment": 0, //don't force a space after in a comment
+        //our indentation
+        "indent": [2, 4, {"SwitchCase": 1}],
+        //don't require dangling comma
+        "comma-dangle": 0,
+        //use the global strict keyword
+        "strict": [2, "global"],
+        //allow return in else blocks
+        "no-else-return": 0,
+        //we can use a custom rule for func names
+        "func-names": 0,
+        //don't force a space after in a comment
+        "spaced-comment": 0,
         "id-length": [2, {"min": 2, "properties": "never", "exceptions": ["$", "_", "i", "j", "k", "x", "y", "z"]}],
-        "one-var": 0, //we don't use one var keyword for all defs
-        "no-throw-literal": 0, //we sometimes throw strings, which is ok
-        "radix": 0, //don't force a radix
-        "eol-last": 1, //warn when file doesn't end with newline
-        "no-multi-spaces": 0, //we do .constant('blah',     require('blah')) a lot,
-        "no-irregular-whitespace": 0, //Some files have a BOM, doesn't seem to cause us problems
-        "no-trailing-spaces": 0, //VS doesn't clean up extra spaces on new lines, so this is annoying
+        //we don't use one var keyword for all defs
+        "one-var": 0,
+        //we sometimes throw strings, which is ok
+        "no-throw-literal": 0,
+        //don't force a radix
+        "radix": 0,
+        //warn when file doesn't end with newline
+        "eol-last": 1,
+        //we do .constant('blah',     require('blah')) a lot,
+        "no-multi-spaces": 0,
+        //VS doesn't clean up extra spaces on new lines, so this is annoying
+        "no-trailing-spaces": 0,
         "no-param-reassign": [2, { "props": false }],
         "space-before-function-paren": [2, "never"],
         "import/no-unresolved": 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-buildium",
-  "version": "3.0.0",
+  "version": "4.0.0-0",
   "description": "Buildium's ESLint config, based on AirBnB's ES5 config",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,8 @@
   },
   "keywords": [
     "eslint",
-    "eslintconfig"
+    "eslintconfig",
+    "eslint-config"
   ],
   "author": "Jeff Balboni <jeff.balboni@buildium.com>",
   "license": "MIT",
@@ -22,7 +23,7 @@
   "homepage": "https://github.com/buildium/eslint-config-buildium#readme",
   "dependencies": {},
   "peerDependencies": {
-    "eslint-plugin-buildium": "2.0.0",
-    "eslint-config-airbnb": "9.0.1"
+    "eslint-plugin-buildium": "^2.0.0",
+    "eslint-config-airbnb-base": "~11.1.3"
   }
 }


### PR DESCRIPTION
- `eslint-config-airbnb` has dependencies on `eslint-plugin-jsx-a11y` and
`eslint-plugin-react` which we don't use (we've extended _airbnb/legacy_)

- removes the _no-irregular-whitespace_ override since this *has* caused
us problems