### PR TITLE
Override airbnb base

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -1,9 +1,11 @@
 module.exports = {
-    "sourceType": "script",  //override airbnb-base
     "extends": "airbnb-base",
     "plugins": [
         "buildium"
     ],
+    parserOptions: {
+        sourceType: 'script' //override airbnb-base
+    },
     "rules": {
         //our indentation
         "indent": [2, 4, {"SwitchCase": 1}],
@@ -51,6 +53,10 @@ module.exports = {
         "buildium/tagged-templates": 2,
         //Overriding airbnb-base, we are not adapting these yet
         "prefer-const": 0,
-        "prefer-arrow-callback": 0
+        "prefer-arrow-callback": 0,
+        "linebreak-style": 0,
+        "arrow-parens": 0,
+        "import/newline-after-import": 0,
+        "import/no-extraneous-dependencies": 0
     }
 };

--- a/eslintrc.js
+++ b/eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+    "sourceType": "script" //override airbnb-base
     "extends": "airbnb-base",
     "plugins": [
         "buildium"
@@ -47,6 +48,9 @@ module.exports = {
         "buildium/imports-jquery": 2,
         "buildium/imports-angular-bsfy": 2,
         "buildium/arrow-function-callback": 2,
-        "buildium/tagged-templates": 2
+        "buildium/tagged-templates": 2,
+        //Overriding airbnb-base, we are not adapting these yet
+        "prefer-const": 0,
+        "prefer-arrow-callback": 0
     }
 };

--- a/eslintrc.js
+++ b/eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-    "sourceType": "script" //override airbnb-base
+    "sourceType": "script",  //override airbnb-base
     "extends": "airbnb-base",
     "plugins": [
         "buildium"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-buildium",
-  "version": "5.0.0",
+  "version": "5.0.1-0",
   "description": "Buildium's ESLint config, based on AirBnB's ES5 config",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-buildium",
-  "version": "5.1.0",
+  "version": "5.1.1-0",
   "description": "Buildium's ESLint config, based on AirBnB's ES5 config",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-buildium",
-  "version": "5.0.1-2",
+  "version": "5.1.0",
   "description": "Buildium's ESLint config, based on AirBnB's ES5 config",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-buildium",
-  "version": "5.0.1-0",
+  "version": "5.0.1-1",
   "description": "Buildium's ESLint config, based on AirBnB's ES5 config",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-buildium",
-  "version": "5.0.1-1",
+  "version": "5.0.1-2",
   "description": "Buildium's ESLint config, based on AirBnB's ES5 config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
These changes are needed because in version 4.0.0 (never applied to buildiumcode) we switched to airbnb-base which added a few more rules we don't do right now