### PR TITLE
Enforce to not use object shorthand as it breaks release build

### DIFF
--- a/eslintrc.js
+++ b/eslintrc.js
@@ -58,8 +58,8 @@ module.exports = {
         "arrow-parens": 0,
         "import/newline-after-import": 0,
         "import/no-extraneous-dependencies": 0,
-        //Cannot do this yet
-        "object-shorthand": 0,
+        //Our release build does not support object shorthand yet
+        "object-shorthand": ['error', 'never'],
         "arrow-body-style": 0,
         'no-restricted-properties': ['error', {
           object: 'arguments',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-buildium",
-  "version": "5.4.1-0",
+  "version": "5.5.0",
   "description": "Buildium's ESLint config, based on AirBnB's ES5 config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Until release build is update to allow this, we will have to enforce no object shorthand so it doesn't break the release build